### PR TITLE
refactor docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,53 @@
-FROM buildpack-deps:xenial
+# Use current NodeJS LTS version (10.x), slim variant.
+#
+# Typically we would use node:10-alpine for the smallest possible image, but
+# some of the JS deps here want to take advantage of sodium-native, which
+# currently does not bundle a "pre-build" version for MUSL Linux. Thus we use
+# slim instead for now, and trade a bit of extra image size for not needing to
+# do as much compilation at build time.
+#
+# In the future, it may be desirable to just do this compilation so we can use
+# alpine linux if we want a smaller image, or even to help contribute to the
+# upstream project to have a MUSL prebuild.[1]
+# 
+# [1]: https://github.com/sodium-friends/sodium-native/issues/33
+FROM node:10-slim
 
-RUN groupadd -r node
-RUN useradd -r -g node node
+# Install node_modules.
+#
+# Additional explanations:
+#
+#  - By copying the package*.json files and then doing the installation of node
+#    modules as a step prior to copying the JS source code, it uses layer
+#    ordering such that typical changes to the JS source do not require
+#    reinstalling/rebuilding the node_modules, as those cache layers remain
+#    valid.
+#
+#  - NPM "ci" is best used when installing from a package-lock.json. It's
+#    significantly faster, and relies upon the lock file versions as the source
+#    of truth, instead of trying to potentially upgrade deps.
+COPY package*.json ./
+RUN apt-get update && apt-get install -y git \
+    && npm ci \
+    && apt-get remove --purge -y git \
+    && rm -rf /var/lib/apt/lists/*
+# NOTE: The only reason the installation git is needed above is because of the
+# dependency on a GitHub repo in package.json for an unpublished package
+# (scuttlebutt-akka-persistence-index). We remove it right after install (in the
+# same command) to avoid bloating the layer filesize. However, once this is
+# switched to a published npm package, the entire command can just be replaced
+# with "RUN npm ci", which will be much faster.
 
-RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
+# Add the source for the server
+COPY index.js .
 
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-ENV NVM_DIR $HOME/.nvm
-RUN . $HOME/.nvm/nvm.sh 
-RUN . $HOME/.nvm/nvm.sh && nvm install 8.10.0 && nvm alias default 8.10.0
-
-RUN git clone https://github.com/jedisct1/libsodium.git
-RUN cd /libsodium && git checkout
-RUN cd /libsodium && ./autogen.sh
-RUN cd /libsodium && ./configure && make && make check && make install
-
-RUN mkdir -p /usr/src/ssb
-WORKDIR /usr/src/ssb
-
-COPY package.json /usr/src/ssb/
-COPY index.js /usr/src/ssb/
-
-RUN . $HOME/.nvm/nvm.sh && npm install
-
-EXPOSE 8009
-
-ENV NPM_CONFIG_LOGLEVEL info
-
-# The /usr/src/ssb/data can be mounted by the host to use its secret file for connecting
-# to the ssb server over RPC as a client
-
-# e.g. docker run -v <local path>:/usr/src/ssb/data <image id>
-
-CMD . $HOME/.nvm/nvm.sh && npm run start -- -d "/usr/src/ssb/data" -p 8009
-
-
-
-
+# Conf values as env vars so they can be easily overriden at run time.
+#
+# The /usr/src/ssb/data can be mounted by the host to use its secret file for
+# connecting to the ssb server over RPC as a client.
+# e.g. docker run -v <local path>:/usr/src/ssb/data -p 8009:8009 <image id>
+ENV NPM_CONFIG_LOGLEVEL=info
+ENV DATA=/usr/src/ssb/data
+ENV PORT=8009
+ENTRYPOINT ["npm", "run", "start", "--"]
+CMD ["-d", "$DATA", "-p", "$PORT"]

--- a/index.js
+++ b/index.js
@@ -17,8 +17,10 @@ const invite = options.invite;
 const generateInvite = options.generate;
 
 if (!port || !dir) {
-    console.log("Port and dir flags required.");
+    console.log("Fatal: port (-p) and dir (-d) flags required.");
+    process.exit(1);
 }
+console.log(`Starting on port ${port} using data directory ${dir} ...`);
 
 function createSbot() {
 


### PR DESCRIPTION
Gordon let's do a quick conf call pairing and I can walk you through some of the process leading to these changes as a means of knowledge sharing and discuss any other changes we might wan tot make, but here's the high level:

Build time:
```
docker build --no-cache -t ssb:legacy .  0.25s user 0.25s system 0% cpu 2:55.51 total
docker build --no-cache -t ssb:new .  0.09s user 0.07s system 0% cpu 26.030 total
```

Additionally, if just modifying the `index.js` source, the new image can be rebuilt from cache
in under a second (whereas the previous version would repeat the `node_modules` dependency compilation, taking a few minutes).

Size:
```
$ docker images | grep ssb
ssb:new                 0331c4884910        3 minutes ago       328MB
ssb:legacy              d66eb2c68b62        24 hours ago        935MB
```

The file size is not as small as an alpine variant (see inline comments for explanation), but this was simpler for now (I managed to get the alpine variant down to 147mb, but it's build file is more complex so figured better to wait until needed).
